### PR TITLE
added catkin_package to properly deal with dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,3 +13,6 @@ generate_messages(
   DEPENDENCIES std_msgs sensor_msgs geometry_msgs
 )
 
+catkin_package(
+  CATKIN_DEPENDS message_runtime
+)


### PR DESCRIPTION
It is suggested to do this here: http://wiki.ros.org/ROS/Tutorials/CreatingMsgAndSrv
Otherwise when you add ras_msgs to find_package it will spit out the cannot find config file message.
